### PR TITLE
Change host port requests to "LoadBalancer" and allow user to specify only internal services.

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Constants.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Constants.cs
@@ -69,6 +69,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
 
         public const string EdgeAgentServiceAccountName = "ServiceAccountName";
 
+        public const string SetAllServicesToClusterIP = "ServicesInClusterOnly";
+
         public const string EnableK8sServiceCallTracingName = "EnableK8sServiceCallTracing";
 
         public const string EdgeletAuthSchemeVariableName = "IOTEDGE_AUTHSCHEME";

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -132,6 +132,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                         string proxyConfigPath = configuration.GetValue<string>(CoreConstant.ProxyConfigPathEnvKey);
                         string proxyConfigVolumeName = configuration.GetValue<string>(CoreConstant.ProxyConfigVolumeEnvKey);
                         string serviceAccountName = configuration.GetValue<string>(CoreConstant.EdgeAgentServiceAccountName);
+                        bool servicesInClusterOnly = configuration.GetValue<bool>(CoreConstant.SetAllServicesToClusterIP);
                         bool enableServiceCallTracing = configuration.GetValue<bool>(CoreConstant.EnableK8sServiceCallTracingName);
 
                         builder.RegisterModule(new AgentModule(maxRestartCount, intensiveCareTime, coolOffTimeUnitInSeconds, usePersistentStorage, storagePath, Option.Some(new Uri(workloadUri)), moduleId, Option.Some(moduleGenerationId)));
@@ -148,6 +149,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                             dockerAuthConfig,
                             upstreamProtocol,
                             productInfo,
+                            servicesInClusterOnly,
                             enableServiceCallTracing));
                         break;
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/appsettings_agent.json
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/appsettings_agent.json
@@ -30,5 +30,6 @@
   "ProxyConfigPath": "/etc/traefik",
   "ProxyConfigVolume": "<Config Map Volume Name>",
   "ServiceAccountName": "",
+  "ServicesInClusterOnly" :  false, 
   "EnableK8sServiceCallTracing": false
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/KubernetesModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/KubernetesModule.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
         readonly IEnumerable<AuthConfig> dockerAuthConfig;
         readonly Option<UpstreamProtocol> upstreamProtocol;
         readonly Option<string> productInfo;
+        readonly bool servicesInClusterOnly;
         readonly bool enableServiceCallTracing;
 
         public KubernetesModule(
@@ -53,6 +54,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             IEnumerable<AuthConfig> dockerAuthConfig,
             Option<UpstreamProtocol> upstreamProtocol,
             Option<string> productInfo,
+            bool servicesInClusterOnly,
             bool enableServiceCallTracing)
         {
             this.iotHubHostname = Preconditions.CheckNonWhiteSpace(iotHubHostname, nameof(iotHubHostname));
@@ -67,6 +69,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             this.dockerAuthConfig = Preconditions.CheckNotNull(dockerAuthConfig, nameof(dockerAuthConfig));
             this.upstreamProtocol = Preconditions.CheckNotNull(upstreamProtocol, nameof(upstreamProtocol));
             this.productInfo = productInfo;
+            this.servicesInClusterOnly = servicesInClusterOnly;
             this.enableServiceCallTracing = enableServiceCallTracing;
         }
 
@@ -168,6 +171,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
                         this.serviceAccountName,
                         this.workloadUri,
                         this.managementUri,
+                        this.servicesInClusterOnly,
                         c.Resolve<IKubernetes>()) as IRuntimeInfoProvider))
                 .As<Task<IRuntimeInfoProvider>>()
                 .SingleInstance();

--- a/edgelet/build/charts/edge-kubernetes/templates/edge-agent-deployment.yaml
+++ b/edgelet/build/charts/edge-kubernetes/templates/edge-agent-deployment.yaml
@@ -67,6 +67,8 @@ spec:
             value: {{ include "edge-kubernetes.fullname" . }}-iotedged-proxy-config
           - name: "ServiceAccountName"
             value: "{{.Release.Name}}-service-account"
+          - name: "ServicesInClusterOnly"
+            value: {{ .Values.edgeAgent.env.servicesInClusterOnly | quote }}
           - name: "EnableK8sServiceCallTracing"
             value: {{ .Values.edgeAgent.env.enableK8sServiceCallTracing | quote }}
           - name: "K8sNamespaceBaseName"

--- a/edgelet/build/charts/edge-kubernetes/values.yaml
+++ b/edgelet/build/charts/edge-kubernetes/values.yaml
@@ -52,6 +52,10 @@ edgeAgent:
     # This variable isn't really used in k8s mode.
     networkId: 'azure-iot-edge'
     authScheme: 'sasToken'
+    # We assume that if the user has mapped a container port to the host, they want 
+    # it exposed on a public IP on the cluster (Service type is LoadBalancer). 
+    # Set this to true if you want to define your own external services.
+    servicesInClusterOnly: false
     # Set this to false if you want to turn off verbose k8s call tracing
     enableK8sServiceCallTracing: false
     # Configure edge agent log verbosity


### PR DESCRIPTION

-    Our Service Logic for mapped ports changed slightly, and now we are defaulting to "loadBalancer" service type.
-    User now may tell edge runtime to only create services internal to cluster (ClusterIp), so that the user may choose how to expose services outside the cluster.
