### PR TITLE
Dwr user chooses servicetype

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Constants.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Constants.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
 
         public const string EdgeAgentServiceAccountName = "ServiceAccountName";
 
-        public const string SetAllServicesToClusterIP = "ServicesInClusterOnly";
+        public const string PortMappingServiceType = "PortMappingServiceType";
 
         public const string EnableK8sServiceCallTracingName = "EnableK8sServiceCallTracing";
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/Constants.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/Constants.cs
@@ -40,5 +40,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
 
         public const string ModuleConfigMap = "moduleconfigmap";
 
+        public const PortMapServiceType DefaultPortMapServiceType = PortMapServiceType.ClusterIP;
+
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/PortMapServiceType.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/PortMapServiceType.cs
@@ -1,0 +1,22 @@
+namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Runtime.Serialization;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum PortMapServiceType
+    {
+        [EnumMember(Value = "ClusterIP")]
+        ClusterIP,
+
+        [EnumMember(Value = "LoadBalancer")]
+        LoadBalancer,
+
+        [EnumMember(Value = "NodePort")]
+        NodePort,
+
+    }
+}

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                         string proxyConfigPath = configuration.GetValue<string>(CoreConstant.ProxyConfigPathEnvKey);
                         string proxyConfigVolumeName = configuration.GetValue<string>(CoreConstant.ProxyConfigVolumeEnvKey);
                         string serviceAccountName = configuration.GetValue<string>(CoreConstant.EdgeAgentServiceAccountName);
-                        bool servicesInClusterOnly = configuration.GetValue<bool>(CoreConstant.SetAllServicesToClusterIP);
+                        Kubernetes.PortMapServiceType mappedServiceDefault = GetDefaultServiceType(configuration);
                         bool enableServiceCallTracing = configuration.GetValue<bool>(CoreConstant.EnableK8sServiceCallTracingName);
 
                         builder.RegisterModule(new AgentModule(maxRestartCount, intensiveCareTime, coolOffTimeUnitInSeconds, usePersistentStorage, storagePath, Option.Some(new Uri(workloadUri)), moduleId, Option.Some(moduleGenerationId)));
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                             dockerAuthConfig,
                             upstreamProtocol,
                             productInfo,
-                            servicesInClusterOnly,
+                            mappedServiceDefault,
                             enableServiceCallTracing));
                         break;
 
@@ -274,6 +274,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
 
             return storagePath;
         }
+
+        static Kubernetes.PortMapServiceType GetDefaultServiceType(IConfiguration configuration) =>
+            Enum.TryParse(configuration.GetValue(CoreConstant.PortMappingServiceType, string.Empty), true, out Kubernetes.PortMapServiceType defaultServiceType)
+                ? defaultServiceType
+                : Kubernetes.Constants.DefaultPortMapServiceType;
 
         static void LogLogo(ILogger logger)
         {

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/appsettings_agent.json
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/appsettings_agent.json
@@ -30,6 +30,6 @@
   "ProxyConfigPath": "/etc/traefik",
   "ProxyConfigVolume": "<Config Map Volume Name>",
   "ServiceAccountName": "",
-  "ServicesInClusterOnly" :  false, 
+  "PortMappingServiceType": "ClusterIP",
   "EnableK8sServiceCallTracing": false
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/KubernetesModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/KubernetesModule.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
         readonly IEnumerable<AuthConfig> dockerAuthConfig;
         readonly Option<UpstreamProtocol> upstreamProtocol;
         readonly Option<string> productInfo;
-        readonly bool servicesInClusterOnly;
+        readonly PortMapServiceType defaultMapServiceType;
         readonly bool enableServiceCallTracing;
 
         public KubernetesModule(
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             IEnumerable<AuthConfig> dockerAuthConfig,
             Option<UpstreamProtocol> upstreamProtocol,
             Option<string> productInfo,
-            bool servicesInClusterOnly,
+            PortMapServiceType defaultMapServiceType,
             bool enableServiceCallTracing)
         {
             this.iotHubHostname = Preconditions.CheckNonWhiteSpace(iotHubHostname, nameof(iotHubHostname));
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             this.dockerAuthConfig = Preconditions.CheckNotNull(dockerAuthConfig, nameof(dockerAuthConfig));
             this.upstreamProtocol = Preconditions.CheckNotNull(upstreamProtocol, nameof(upstreamProtocol));
             this.productInfo = productInfo;
-            this.servicesInClusterOnly = servicesInClusterOnly;
+            this.defaultMapServiceType = defaultMapServiceType;
             this.enableServiceCallTracing = enableServiceCallTracing;
         }
 
@@ -171,7 +171,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
                         this.serviceAccountName,
                         this.workloadUri,
                         this.managementUri,
-                        this.servicesInClusterOnly,
+                        this.defaultMapServiceType,
                         c.Resolve<IKubernetes>()) as IRuntimeInfoProvider))
                 .As<Task<IRuntimeInfoProvider>>()
                 .SingleInstance();

--- a/edgelet/build/charts/edge-kubernetes/templates/_helpers.tpl
+++ b/edgelet/build/charts/edge-kubernetes/templates/_helpers.tpl
@@ -36,6 +36,12 @@ Create chart name and version as used by the chart label.
 provisioning:
   source: "manual"
   device_connection_string: {{ .Values.deviceConnectionString | quote }}
+{{- if .Values.iotedged.certificates }}
+certificates:
+  device_ca_cert: "/etc/edgecerts/device_ca_cert"
+  device_ca_pk: "/etc/edgecerts/device_ca_pk"
+  trusted_ca_certs: "/etc/edgecerts/trusted_ca_certs"
+{{ end }}
 agent:
   name: "edgeAgent"
   type: "docker"

--- a/edgelet/build/charts/edge-kubernetes/templates/edge-agent-deployment.yaml
+++ b/edgelet/build/charts/edge-kubernetes/templates/edge-agent-deployment.yaml
@@ -67,8 +67,8 @@ spec:
             value: {{ include "edge-kubernetes.fullname" . }}-iotedged-proxy-config
           - name: "ServiceAccountName"
             value: "{{.Release.Name}}-service-account"
-          - name: "ServicesInClusterOnly"
-            value: {{ .Values.edgeAgent.env.servicesInClusterOnly | quote }}
+          - name: "PortMappingServiceType"
+            value: {{ .Values.edgeAgent.env.portMappingServiceType | quote }}
           - name: "EnableK8sServiceCallTracing"
             value: {{ .Values.edgeAgent.env.enableK8sServiceCallTracing | quote }}
           - name: "K8sNamespaceBaseName"

--- a/edgelet/build/charts/edge-kubernetes/templates/iotedged-config-secret.yaml
+++ b/edgelet/build/charts/edge-kubernetes/templates/iotedged-config-secret.yaml
@@ -34,3 +34,19 @@ data:
     {{ include "edge-kubernetes.regcreds" . | fromYaml | toJson | b64enc }}
 ...
 {{ end }}
+{{- if .Values.iotedged.certificates }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "edge-kubernetes.fullname" . }}-edgecerts
+  namespace: {{ include "edge-kubernetes.namespace" . | quote }}
+type: Opaque
+data:
+  device_ca_cert: |-
+    {{ .Files.Get .Values.iotedged.certificates.device_ca_cert | b64enc }}
+  device_ca_pk: |-
+    {{ .Files.Get .Values.iotedged.certificates.device_ca_pk | b64enc }}
+  trusted_ca_certs: |-
+    {{ .Files.Get .Values.iotedged.certificates.trusted_ca_certs | b64enc }}
+{{ end }}

--- a/edgelet/build/charts/edge-kubernetes/templates/iotedged-deployment.yaml
+++ b/edgelet/build/charts/edge-kubernetes/templates/iotedged-deployment.yaml
@@ -32,6 +32,11 @@ spec:
             readOnly: true
           - name: edge-home
             mountPath: {{ .Values.iotedged.data.targetPath | quote }}
+          {{- if .Values.iotedged.certificates }}
+          - name: edge-certs
+            mountPath: "/etc/edgecerts"
+            readOnly: true
+          {{end}}
           ports:
             - name: management
               containerPort: {{ .Values.iotedged.ports.management }}
@@ -56,11 +61,20 @@ spec:
       - name: config
         secret:
           secretName: {{ include "edge-kubernetes.fullname" . }}-iotedged-config
+      {{- if .Values.iotedged.certificates }}
+      {{- /*
+        NOTE: This sets up iotedged with a volume "/etc/edgecerts" populated with the given CA certs.
+      */}}
+      - name: edge-certs
+        secret:
+          secretName: {{ include "edge-kubernetes.fullname" . }}-edgecerts
+      {{else}}
       {{- /*
         NOTE: This sets up iotedged in the "quickstart" mode which is NOT meant
         for production use. For PoCs though, its wonderful! For production, this
         volume should probably be populated with proper CA certs.
       */}}
+      {{end}}
       - name: edge-home
         {{- if .Values.iotedged.data.persistentVolumeClaim }}
         persistentVolumeClaim:

--- a/edgelet/build/charts/edge-kubernetes/values.yaml
+++ b/edgelet/build/charts/edge-kubernetes/values.yaml
@@ -24,6 +24,21 @@ iotedged:
     # persistentVolumeClaim:
     #   name: <CLAIM NAME HERE>
     #   storageClassName: <STORAGE CLASS NAME HERE>
+  ###############################################################################
+  # Certificate settings
+  ###############################################################################
+  #
+  # Configures the certificates required to operate the IoT Edge
+  # runtime as a gateway which enables external leaf devices to securely
+  # communicate with the Edge Hub. If not specified, the required certificates
+  # are auto generated for quick start scenarios which are not intended for
+  # production environments.
+  #
+  # certificates:
+  #   device_ca_cert: "<ADD PATH TO DEVICE CA CERTIFICATE HERE>"
+  #   device_ca_pk: "<ADD PATH TO DEVICE CA PRIVATE KEY HERE>"
+  #   trusted_ca_certs: "<ADD PATH TO TRUSTED CA CERTIFICATES HERE>"
+
 
 iotedgedProxy:
   image:

--- a/edgelet/build/charts/edge-kubernetes/values.yaml
+++ b/edgelet/build/charts/edge-kubernetes/values.yaml
@@ -52,10 +52,9 @@ edgeAgent:
     # This variable isn't really used in k8s mode.
     networkId: 'azure-iot-edge'
     authScheme: 'sasToken'
-    # We assume that if the user has mapped a container port to the host, they want 
-    # it exposed on a public IP on the cluster (Service type is LoadBalancer). 
-    # Set this to true if you want to define your own external services.
-    servicesInClusterOnly: false
+    # Set this to one of "LoadBalancer", "NodePort", or "ClusterIP" to tell the 
+    # IoT Edge runtime how you want to expose mapped ports as Services.
+    portMappingServiceType: 'ClusterIP'
     # Set this to false if you want to turn off verbose k8s call tracing
     enableK8sServiceCallTracing: false
     # Configure edge agent log verbosity


### PR DESCRIPTION
Two minor changes here:
1. User may set PortMappingServiceType=LoadBalancer|NodePort|ClusterIP to assign the service type to ports with host mapping.  Default is "ClusterIP".
2. Helm charts  have been updated to allow "transparent gateway scenario" add the following to the override, and the iotedged will use these certs for TCP ports.  

```yaml
iotedged:
  certificates:
    device_ca_cert: "<CERTDIR>\\certs\\new-edge-device-full-chain.cert.pem"
    device_ca_pk: "<CERTDIR>\\private\\new-edge-device.key.pem"
    trusted_ca_certs: "<CERTDIR>\\certs\\azure-iot-test-only.root.ca.cert.pem"
```