### PR TITLE
Remove Hub and Device IDs from Deployment and Pod names.

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/EdgeOperator.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/EdgeOperator.cs
@@ -510,7 +510,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
                 });
         }
 
-        string DeploymentName(string moduleId) => KubeUtils.SanitizeK8sValue(this.iotHubHostname + "-" + this.deviceId + "-" + moduleId);
+        string DeploymentName(string moduleId) => KubeUtils.SanitizeK8sValue(moduleId);
 
         async void ManageDeployments(V1ServiceList currentServices, V1DeploymentList currentDeployments, EdgeDeploymentDefinition customObject)
         {

--- a/edgelet/build/charts/edge-kubernetes/templates/edge-agent-deployment.yaml
+++ b/edgelet/build/charts/edge-kubernetes/templates/edge-agent-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: '{{ include "edge-kubernetes.hostname" . }}-{{ include "edge-kubernetes.deviceid" . }}-edgeagent'
+  name: 'edgeagent'
   namespace: {{ include "edge-kubernetes.namespace" . | quote }}
   labels:
     app.kubernetes.io/name: {{ include "edge-kubernetes.name" . }}-edge-agent

--- a/edgelet/build/charts/edge-kubernetes/templates/iotedged-deployment.yaml
+++ b/edgelet/build/charts/edge-kubernetes/templates/iotedged-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "edge-kubernetes.fullname" . }}-iotedged
+  name: iotedged
   namespace: {{ include "edge-kubernetes.namespace" . | quote }}
   labels:
     app.kubernetes.io/name: {{ include "edge-kubernetes.name" . }}-iotedged


### PR DESCRIPTION
Since each device exists in its own namepace, we don't need the
hub/device name for each module.